### PR TITLE
Add mistral llm

### DIFF
--- a/.env.tpl
+++ b/.env.tpl
@@ -1,3 +1,3 @@
-OPENAI_API_KEY=""
+API_KEY=""
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [2.0.0] - 2024-02-26
+
+### Added
+
+- Support for using Mistral as an alternative to ChatGPT for document generation. This allows users to choose Mistral for content generation by specifying `mistral` as the `modelProvider`.
+
+### Changed
+
+- **Breaking Change**: `modelName` is now required. The previous default value of `gpt-4` has been removed to encourage users to explicitly specify the model they wish to use.
+- **Breaking Change**: `modelProvider` is required. Users must choose between `mistral` and `openAI` as the model provider. This change aims to clarify the source of the language model being used and to offer more flexibility.
+- The `openAi` configuration has been deleted and replaced with a new `llm` structure, which includes `apiKey` for specifying your API key, and `modelProvider` and `modelName` for defining the model provider and model name, respectively. This approach streamlines the configuration for better consistency and ease of use.
+
+### Deprecations
+
+- The `openAi` object is officially deprecated and replaced by `llm` for better representation of the language model configuration.
+
+### Environment Updates
+
+- The `OPEN_API_KEY` environment variable has been renamed to `API_KEY` for the CLI version, to standardize the naming of environment variables and clarify their use.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ DocAi is a tool that allows you to automatically generate markdown-formatted doc
 
 ## Prerequisites
 
-Your code will be sent to ChatGPT; ensure that you have the rights to do so.
+Your code will be sent to an LLM; ensure that you have the rights to do so.
 
 ## Installation
 
@@ -22,8 +22,10 @@ To document only some files:
 import docai from 'docai'
 
 await docai({
-  openAi: {
-    apiKey: 'YOUR_OPENAI_API_KEY'
+  llm: {
+    apiKey: 'YOUR_API_KEY'
+    modelProvider: 'mistral' | 'openAI'
+    modelName: 'mistral-tiny' | 'gpt-4' | ...
   },
   outputDir: './generated',
   files: ['./test2.ts', './test.js']
@@ -34,8 +36,10 @@ To document your entire project, provide an entrypoint:
 
 ```javascript
 await docai({
-  openAi: {
-    apiKey: 'YOUR_OPENAI_API_KEY'
+  llm: {
+    apiKey: 'YOUR_API_KEY'
+    modelProvider: 'mistral' | 'openAI'
+    modelName: 'mistral-tiny' | 'gpt-4' | ...
   },
   outputDir: './generated',
   entryPoint: './index.js'
@@ -46,8 +50,10 @@ To document routes from your serverless project:
 
 ```javascript
 await docai({
-  openAi: {
-    apiKey: 'YOUR_OPENAI_API_KEY'
+  llm: {
+    apiKey: 'YOUR_API_KEY'
+    modelProvider: 'mistral' | 'openAI'
+    modelName: 'mistral-tiny' | 'gpt-4' | ...
   },
   outputDir: './generated',
   serverlessEntryPoint: './serverless.yml'
@@ -57,9 +63,8 @@ await docai({
 ### Optional Options
 
 - `baseDir`: Defaults to the current directory. Otherwise, provide the directory path.
-- `openAi`:
+- `llm`:
   - `temperature`: Temperature setting for the used model (0 by default).
-  - `modelName`: Name of the OpenAI model to be used (defaults to gpt-4). [List here.](https://platform.openai.com/docs/guides/text-generation)
 - `deleteTmpFolder`: Flag to decide whether or not to delete the temporary folder.
 - `tmpFolderPath`: Path for the temporary folder.
 
@@ -69,19 +74,19 @@ Minimal Configuration:
 Run these commands at the root of your project:
 
 ```bash
-OPENAI_API_KEY="YOUR_API_KEY" docai --output ./documentation --entrypoint ./src/index.js
+API_KEY="YOUR_API_KEY" docai --output ./documentation --entrypoint ./src/index.js --modelProvider openAI --modelName gpt-3.5-turbo
+```
+
+or with Mistral
+
+```bash
+API_KEY="YOUR_API_KEY" docai --output ./documentation --entrypoint /Users/fabien/Projects/gen-doc/mistral-test/test.js --modelProvider mistral --modelName mistral-tiny
 ```
 
 For a serverless project:
 
 ```bash
-OPENAI_API_KEY="YOUR_API_KEY" docai --output ./documentation --modelName chatgpt --serverless ./serverless.yml
-```
-
-Specifying a model:
-
-```bash
-OPENAI_API_KEY="YOUR_API_KEY" docai --output ./documentation --modelName gpt-3.5-turbo --entrypoint ./src/index.js
+API_KEY="YOUR_API_KEY" docai --output ./documentation --modelProvider openAI --modelName gpt-3.5-turbo --serverless ./serverless.yml
 ```
 
 ### Parameters:
@@ -91,13 +96,14 @@ OPENAI_API_KEY="YOUR_API_KEY" docai --output ./documentation --modelName gpt-3.5
 - `output`: Destination folder path. (Required)
 - `baseDir`: Defaults to the current directory. Otherwise, provide the directory path. (Optional)
 - `temperature`: Temperature setting for the used model (0 by default). (Optional)
-- `modelName`: Name of the OpenAI model to be used (defaults to gpt-4). [List here.](https://platform.openai.com/docs/guides/text-generation) (Optional)
+- `modelName`: Name of the LLM model to use
+- `modelProvider`: Name of the LLM Provider to use - openAI or mistral
 - `noDeleteTmp`: Flag to decide whether or not to delete the temporary folder. (Optional)
 - `tmpFolderPath`: Path for the temporary folder. (Optional)
 
 ### Environment Variables:
 
-Only the `OPENAI_API_KEY` environment variable is required.
+Only the `API_KEY` environment variable is required.
 
 ## Examples
 

--- a/__mocks__/@langchain/core/prompts.ts
+++ b/__mocks__/@langchain/core/prompts.ts
@@ -1,0 +1,13 @@
+export const invoke = jest.fn().mockResolvedValue({
+  lc_kwargs: { content: 'mocked content' }
+})
+
+export const pipe = jest.fn(() => ({ invoke }))
+
+export const fromTemplate = jest.fn(() => ({ pipe }))
+
+export const ChatPromptTemplate = jest.fn(() => ({
+  fromTemplate
+})) as any
+
+ChatPromptTemplate.fromTemplate = fromTemplate

--- a/__mocks__/@langchain/mistralai.ts
+++ b/__mocks__/@langchain/mistralai.ts
@@ -1,0 +1,10 @@
+export const ChatMistralAI = jest.fn()
+export const call = jest.fn().mockImplementation(async () => {
+  return await Promise.resolve('mocked response')
+})
+
+ChatMistralAI.mockImplementation(() => {
+  return {
+    call
+  }
+})

--- a/__mocks__/@langchain/openai.ts
+++ b/__mocks__/@langchain/openai.ts
@@ -1,9 +1,9 @@
-export const OpenAI = jest.fn()
+export const ChatOpenAI = jest.fn()
 export const call = jest.fn().mockImplementation(async () => {
   return await Promise.resolve('mocked response')
 })
 
-OpenAI.mockImplementation(() => {
+ChatOpenAI.mockImplementation(() => {
   return {
     call
   }

--- a/__tests__/integration/cli.integration.ts
+++ b/__tests__/integration/cli.integration.ts
@@ -35,7 +35,7 @@ jest.mock('../../_mock/mock-config.ts', () => {
 
 describe('CLI Integration Mocked', () => {
   beforeEach(() => {
-    process.env.OPENAI_API_KEY = 'OPENAI_API_KEY'
+    process.env.API_KEY = 'API_KEY'
     fs.rmSync(path.resolve(`${mockTestFolder}/commented`), {
       recursive: true,
       force: true
@@ -50,9 +50,9 @@ describe('CLI Integration Mocked', () => {
     jest.clearAllMocks()
   })
 
-  it('Should throw an error when OPENAI_API_KEY is not provided', async () => {
-    process.env.OPENAI_API_KEY = ''
-    await expect(cli([])).rejects.toThrow('Missing ENV OPENAI_API_KEY')
+  it('Should throw an error when API_KEY is not provided', async () => {
+    process.env.API_KEY = ''
+    await expect(cli([])).rejects.toThrow('You have to provide an API_KEY')
   })
 
   it('Should generate code', async () => {
@@ -63,7 +63,11 @@ describe('CLI Integration Mocked', () => {
       path.resolve(`${mockTestFolder}/raw`),
       '--output',
       path.resolve(__dirname, '../../_mock/test/markdownUpdated'),
-      '--mocked'
+      '--mocked',
+      '--modelProvider',
+      'openAI',
+      '--modelName',
+      'gpt-4'
     ])
 
     const fileContent = fs.readFileSync(
@@ -92,7 +96,11 @@ const {
       path.resolve(`${mockTestFolder}/raw`),
       '--output',
       path.resolve(__dirname, '../../_mock/test/markdownUpdated'),
-      '--mocked'
+      '--mocked',
+      '--modelProvider',
+      'openAI',
+      '--modelName',
+      'gpt-4'
     ])
 
     const fileContent = fs.readFileSync(
@@ -116,7 +124,11 @@ This file contains two distinct parts. The first part is a JavaScript module tha
       path.resolve(`${mockTestFolder}/raw`),
       '--output',
       path.resolve(__dirname, '../../_mock/test/markdownUpdated'),
-      '--mocked'
+      '--mocked',
+      '--modelProvider',
+      'openAI',
+      '--modelName',
+      'gpt-4'
     ])
 
     const fileContent = fs.readFileSync(

--- a/__tests__/integration/index.integration.ts
+++ b/__tests__/integration/index.integration.ts
@@ -63,8 +63,10 @@ describe('Index Integration Mocked', () => {
       baseDir: path.resolve(`${mockTestFolder}/raw`),
       outputDir: path.resolve(__dirname, '../../_mock/test/markdownUpdated'),
       isMocked: true,
-      openAi: {
-        apiKey: 'OPENAI_API_KEY'
+      llm: {
+        apiKey: 'API_KEY',
+        modelName: 'gpt-3.5',
+        modelProvider: 'openAI'
       }
     })
 
@@ -92,8 +94,10 @@ const {
       baseDir: path.resolve(`${mockTestFolder}/raw`),
       outputDir: path.resolve(__dirname, '../../_mock/test/markdownUpdated'),
       isMocked: true,
-      openAi: {
-        apiKey: 'OPENAI_API_KEY'
+      llm: {
+        apiKey: 'API_KEY',
+        modelName: 'gpt-3.5',
+        modelProvider: 'openAI'
       }
     })
 
@@ -118,8 +122,10 @@ This file contains two distinct parts. The first part is a JavaScript module tha
       baseDir: path.resolve(`${mockTestFolder}/raw`),
       outputDir: path.resolve(__dirname, '../../_mock/test/markdownUpdated'),
       isMocked: true,
-      openAi: {
-        apiKey: 'OPENAI_API_KEY'
+      llm: {
+        apiKey: 'API_KEY',
+        modelName: 'gpt-3.5',
+        modelProvider: 'openAI'
       }
     })
 
@@ -156,8 +162,10 @@ module.exports.handler = createUser
       baseDir: path.resolve(`${mockTestFolder}/raw`),
       outputDir: path.resolve(__dirname, '../../_mock/test/markdownUpdated'),
       isMocked: true,
-      openAi: {
-        apiKey: 'OPENAI_API_KEY'
+      llm: {
+        apiKey: 'API_KEY',
+        modelName: 'gpt-3.5',
+        modelProvider: 'openAI'
       }
     })
 
@@ -191,8 +199,10 @@ module.exports.handler = createUser
       baseDir: path.resolve(`${mockTestFolder}/raw`),
       outputDir: path.resolve(__dirname, '../../_mock/test/markdownUpdated'),
       isMocked: true,
-      openAi: {
-        apiKey: 'OPENAI_API_KEY'
+      llm: {
+        apiKey: 'API_KEY',
+        modelName: 'gpt-3.5',
+        modelProvider: 'openAI'
       }
     })
 

--- a/__tests__/unit/index.spec.ts
+++ b/__tests__/unit/index.spec.ts
@@ -3,7 +3,7 @@ import { docai } from '../../src/index'
 import { addCommentsPerFile } from '../../src/add-comment/index.js'
 import { generateMarkdownFromCommentedCode } from '../../src/generate-doc/index.js'
 import { getHandlerPaths } from '../../src/plugins/serverless/index.js'
-import { initializeOpenAI } from '../../src/llm/model.js'
+import { initializeModel } from '../../src/llm/model.js'
 import type { EntryConfigDocai } from '../../src/types/internal'
 import { writeMarkdownFile } from '../../src/generate-doc/write-markdown.js'
 import { toJestMock } from '../../src/utils/mockType.js'
@@ -18,8 +18,10 @@ describe('Docai index', () => {
   const mockConfig: EntryConfigDocai = {
     outputDir: 'fakeFolderOutput',
     baseDir: 'baseDir',
-    openAi: {
-      apiKey: 'test-key'
+    llm: {
+      apiKey: 'test-key',
+      modelName: 'gpt-4',
+      modelProvider: 'openAI'
     }
   }
 
@@ -35,9 +37,9 @@ describe('Docai index', () => {
   })
 
   it('should throw an error when apiKey is missing', async () => {
-    const config = { ...mockConfig, openAi: undefined }
+    const config = { ...mockConfig, llm: undefined }
     await expect(docai(config as any)).rejects.toThrow(
-      'An OpenAI API KEY is required. Please fill openAI.apiKey'
+      'An API KEY is required. Please fill llm.apiKey'
     )
   })
 
@@ -53,9 +55,9 @@ describe('Docai index', () => {
     )
   })
 
-  it('should initialize OpenAI with correct parameters', async () => {
+  it('should initialize the model with correct parameters', async () => {
     await docai({ ...mockConfig, entryPoint: 'test.js' })
-    expect(initializeOpenAI).toHaveBeenCalledWith(mockConfig.openAi)
+    expect(initializeModel).toHaveBeenCalledWith(mockConfig.llm)
   })
 
   // TODO finir

--- a/__tests__/unit/llm/llm.spec.ts
+++ b/__tests__/unit/llm/llm.spec.ts
@@ -1,48 +1,48 @@
-import type { OpenAI } from 'langchain/llms/openai.js'
+import { ChatPromptTemplate } from '@langchain/core/prompts'
 import {
   generateMarkdown,
   generateCommentFromCode
 } from '../../../src/llm/llm.js'
-import { initializeOpenAI } from '../../../src/llm/model.js'
+import { getModel } from '../../../src/llm/model.js'
+
+jest.mock('../../../src/llm/model.js')
 
 describe('llm', () => {
-  let model: OpenAI
-  beforeEach(() => {
-    model = initializeOpenAI({ apiKey: 'OPEN_AI_API_KEY' })
-  })
-
   afterEach(() => {
     jest.clearAllMocks()
   })
 
   describe('generateMarkdown', () => {
-    it('Should call the OpenAI API with the correct parameters', async () => {
+    it('Should call the llm with correct parameters', async () => {
       const code = 'code'
       const title = 'title'
 
       const result = await generateMarkdown(code, title)
-      expect(model.call).toHaveBeenCalledTimes(1)
-      expect(model.call)
-        .toHaveBeenCalledWith(`You have to write a markdown documentation page for this file: ${code}
+
+      expect(ChatPromptTemplate.fromTemplate).toHaveBeenCalledTimes(1)
+      expect(ChatPromptTemplate.fromTemplate)
+        .toHaveBeenCalledWith(`You have to write a markdown documentation page for this file: {code}
     It should contain only these parts:
-    # ${title}
+    # {title}
     ## Description <!-- Explain what the code does, using the comments you'll find in the code. -->
     ## Code <!-- This section should contains raw code, formatted in Javascript. -->
     ## Use Cases <!-- If you can, give examples to explain what this file does. You can do it by writing a code block which executes functions from the file and display results from their execution in comments. -->`)
-      expect(result).toBe('mocked response')
+      expect(getModel).toHaveBeenCalledTimes(1)
+      expect(result).toBe('mocked content')
     })
   })
 
   describe('generateCommentFromCode', () => {
-    it('Should call the OpenAI API with the correct parameters', async () => {
+    it('Should call the llm with the correct parameters', async () => {
       const code = 'code'
       const result = await generateCommentFromCode(code)
 
-      expect(model.call).toHaveBeenCalledTimes(1)
-      expect(model.call).toHaveBeenCalledWith(
-        `Explain what this code does as fully as possible: ${code}`
+      expect(ChatPromptTemplate.fromTemplate).toHaveBeenCalledTimes(1)
+      expect(ChatPromptTemplate.fromTemplate).toHaveBeenCalledWith(
+        'Explain what this code does as fully as possible: {text}'
       )
-      expect(result).toBe('mocked response')
+      expect(getModel).toHaveBeenCalledTimes(1)
+      expect(result).toBe('mocked content')
     })
   })
 })

--- a/__tests__/unit/llm/model.spec.ts
+++ b/__tests__/unit/llm/model.spec.ts
@@ -1,12 +1,19 @@
 import {
-  initializeOpenAI,
+  initializeModel,
   getModel,
   _resetForTests
 } from '../../../src/llm/model.js'
-import { OpenAI } from 'langchain/llms/openai'
+import { ChatMistralAI } from '@langchain/mistralai'
+import { ChatOpenAI } from '@langchain/openai'
 
 describe('Model', () => {
+  let initModel
   beforeEach(() => {
+    initModel = {
+      apiKey: 'apiKey',
+      modelName: 'gpt-4',
+      modelProvider: 'openAI'
+    }
     _resetForTests()
   })
 
@@ -18,38 +25,56 @@ describe('Model', () => {
     expect(() => getModel()).toThrow('Model has not been initialized yet')
   })
 
-  it('Should throw error if initializeOpenAI is called without apiKey', () => {
-    expect(() => initializeOpenAI({ apiKey: '' })).toThrow('Missing apiKey')
+  it('Should throw error if initializeModel is called without apiKey', () => {
+    initModel.apiKey = ''
+    expect(() => initializeModel(initModel)).toThrow('Missing apiKey')
   })
 
-  it('Should initialize OpenAI model correctly', () => {
-    const modelInstance = initializeOpenAI({ apiKey: 'apiKey' })
-    expect(OpenAI).toHaveBeenCalledTimes(1)
+  it('Should throw error if the modelProvider is not supported', () => {
+    initModel.modelProvider = 'other'
+    expect(() => initializeModel(initModel)).toThrow(
+      'Only openAI and mistral llm are supported. Please choose one'
+    )
+  })
+
+  it('Should initialize ChatOpenAI model correctly', () => {
+    initModel.apiKey = 'apiKey'
+    const modelInstance = initializeModel(initModel)
+    expect(ChatOpenAI).toHaveBeenCalledTimes(1)
     expect(modelInstance).toBeDefined()
   })
 
-  it('Should return the initialized model after calling initializeOpenAI', () => {
-    initializeOpenAI({ apiKey: 'apiKey' })
+  it('Should return the initialized model after calling initializeModel', () => {
+    initializeModel(initModel)
     const modelInstance = getModel()
     expect(modelInstance).toBeDefined()
-    expect(OpenAI).toHaveBeenCalledTimes(1)
+    expect(ChatOpenAI).toHaveBeenCalledTimes(1)
   })
 
-  it('Should not re-initialize if initializeOpenAI is called more than once', () => {
-    initializeOpenAI({ apiKey: 'apiKey' })
-    initializeOpenAI({ apiKey: 'apiKey' })
-    expect(OpenAI).toHaveBeenCalledTimes(1)
+  it('Should not re-initialize if initializeModel is called more than once', () => {
+    initializeModel(initModel)
+    expect(ChatOpenAI).toHaveBeenCalledTimes(1)
   })
 
-  it('Should pass the correct parameters to OpenAI', () => {
-    const params = {
-      modelName: 'test-model',
-      temperature: 5
-    }
-    initializeOpenAI({ ...params, apiKey: 'apiKey' })
-    expect(OpenAI).toHaveBeenCalledWith({
+  it('Should pass the correct parameters to ChatOpenAI', () => {
+    initializeModel(initModel)
+    expect(ChatOpenAI).toHaveBeenCalledWith({
       openAIApiKey: 'apiKey',
-      ...params
+      modelName: 'gpt-4',
+      temperature: 0
+    })
+  })
+
+  it('Should pass the correct parameters to Mistral', () => {
+    initModel.modelProvider = 'mistral'
+    initModel.modelName = 'mistral-tiny'
+    initModel.temperature = 0.5
+
+    initializeModel(initModel)
+    expect(ChatMistralAI).toHaveBeenCalledWith({
+      apiKey: 'apiKey',
+      modelName: 'mistral-tiny',
+      temperature: 0.5
     })
   })
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docai",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "description": "Generate documentation from your code with AI",
   "main": "./dist/src/index.js",
   "type": "module",
@@ -39,9 +39,12 @@
     "@babel/generator": "^7.23.4",
     "@babel/parser": "^7.23.4",
     "@babel/traverse": "^7.23.4",
+    "@langchain/core": "^0.1.33",
+    "@langchain/mistralai": "^0.0.7",
+    "@langchain/openai": "^0.0.14",
     "dependency-tree": "^10.0.9",
     "js-yaml": "^4.1.0",
-    "langchain": "^0.0.172"
+    "langchain": "^0.1.21"
   },
   "devDependencies": {
     "@babel/types": "^7.23.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,15 @@ dependencies:
   '@babel/traverse':
     specifier: ^7.23.4
     version: 7.23.4
+  '@langchain/core':
+    specifier: ^0.1.33
+    version: 0.1.33
+  '@langchain/mistralai':
+    specifier: ^0.0.7
+    version: 0.0.7
+  '@langchain/openai':
+    specifier: ^0.0.14
+    version: 0.0.14
   dependency-tree:
     specifier: ^10.0.9
     version: 10.0.9
@@ -21,8 +30,8 @@ dependencies:
     specifier: ^4.1.0
     version: 4.1.0
   langchain:
-    specifier: ^0.0.172
-    version: 0.0.172
+    specifier: ^0.1.21
+    version: 0.1.21(axios@1.6.7)
 
 devDependencies:
   '@babel/types':
@@ -104,8 +113,8 @@ packages:
       '@jridgewell/trace-mapping': 0.3.20
     dev: true
 
-  /@anthropic-ai/sdk@0.6.8:
-    resolution: {integrity: sha512-z4gDFrBf+W2wOVvwA3CA+5bfKOxQhPeXQo7+ITWj3r3XPulIMEasVT0KrD41G+anr5Yc3d2PKvXKB6b1LSon5w==}
+  /@anthropic-ai/sdk@0.9.1:
+    resolution: {integrity: sha512-wa1meQ2WSfoY8Uor3EdrJq0jTiZJoKoSii2ZVWRY1oN4Tlr5s59pADg9T79FTbPe1/se5c3pBeZgJL63wmuoBA==}
     dependencies:
       '@types/node': 18.18.12
       '@types/node-fetch': 2.6.9
@@ -782,6 +791,323 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
+  /@langchain/community@0.0.32:
+    resolution: {integrity: sha512-jN4BxGKAmLbA87hqXH5Mx1IRMMVOgcn1TY1MLOVyBcBa12EvHFx8suogtXgA2ekfc8U8nIryVb1ftSupwUBv/A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@aws-crypto/sha256-js': ^5.0.0
+      '@aws-sdk/client-bedrock-agent-runtime': ^3.485.0
+      '@aws-sdk/client-bedrock-runtime': ^3.422.0
+      '@aws-sdk/client-dynamodb': ^3.310.0
+      '@aws-sdk/client-kendra': ^3.352.0
+      '@aws-sdk/client-lambda': ^3.310.0
+      '@aws-sdk/client-sagemaker-runtime': ^3.310.0
+      '@aws-sdk/client-sfn': ^3.310.0
+      '@aws-sdk/credential-provider-node': ^3.388.0
+      '@azure/search-documents': ^12.0.0
+      '@clickhouse/client': ^0.2.5
+      '@cloudflare/ai': '*'
+      '@datastax/astra-db-ts': ^0.1.4
+      '@elastic/elasticsearch': ^8.4.0
+      '@getmetal/metal-sdk': '*'
+      '@getzep/zep-js': ^0.9.0
+      '@gomomento/sdk': ^1.51.1
+      '@gomomento/sdk-core': ^1.51.1
+      '@google-ai/generativelanguage': ^0.2.1
+      '@gradientai/nodejs-sdk': ^1.2.0
+      '@huggingface/inference': ^2.6.4
+      '@mozilla/readability': '*'
+      '@opensearch-project/opensearch': '*'
+      '@pinecone-database/pinecone': '*'
+      '@planetscale/database': ^1.8.0
+      '@qdrant/js-client-rest': ^1.2.0
+      '@raycast/api': ^1.55.2
+      '@rockset/client': ^0.9.1
+      '@smithy/eventstream-codec': ^2.0.5
+      '@smithy/protocol-http': ^3.0.6
+      '@smithy/signature-v4': ^2.0.10
+      '@smithy/util-utf8': ^2.0.0
+      '@supabase/postgrest-js': ^1.1.1
+      '@supabase/supabase-js': ^2.10.0
+      '@tensorflow-models/universal-sentence-encoder': '*'
+      '@tensorflow/tfjs-converter': '*'
+      '@tensorflow/tfjs-core': '*'
+      '@upstash/redis': ^1.20.6
+      '@upstash/vector': ^1.0.2
+      '@vercel/kv': ^0.2.3
+      '@vercel/postgres': ^0.5.0
+      '@writerai/writer-sdk': ^0.40.2
+      '@xata.io/client': ^0.28.0
+      '@xenova/transformers': ^2.5.4
+      '@zilliz/milvus2-sdk-node': '>=2.2.7'
+      better-sqlite3: ^9.4.0
+      cassandra-driver: ^4.7.2
+      chromadb: '*'
+      closevector-common: 0.1.3
+      closevector-node: 0.1.6
+      closevector-web: 0.1.6
+      cohere-ai: '*'
+      convex: ^1.3.1
+      discord.js: ^14.14.1
+      dria: ^0.0.3
+      faiss-node: ^0.5.1
+      firebase-admin: ^11.9.0 || ^12.0.0
+      google-auth-library: ^8.9.0
+      googleapis: ^126.0.1
+      hnswlib-node: ^1.4.2
+      html-to-text: ^9.0.5
+      ioredis: ^5.3.2
+      jsdom: '*'
+      llmonitor: ^0.5.9
+      lodash: ^4.17.21
+      lunary: ^0.6.11
+      mongodb: '>=5.2.0'
+      mysql2: ^3.3.3
+      neo4j-driver: '*'
+      node-llama-cpp: '*'
+      pg: ^8.11.0
+      pg-copy-streams: ^6.0.5
+      pickleparser: ^0.2.1
+      portkey-ai: ^0.1.11
+      redis: '*'
+      replicate: ^0.18.0
+      typeorm: ^0.3.12
+      typesense: ^1.5.3
+      usearch: ^1.1.1
+      vectordb: ^0.1.4
+      voy-search: 0.6.2
+      weaviate-ts-client: '*'
+      web-auth-library: ^1.0.3
+      ws: ^8.14.2
+    peerDependenciesMeta:
+      '@aws-crypto/sha256-js':
+        optional: true
+      '@aws-sdk/client-bedrock-agent-runtime':
+        optional: true
+      '@aws-sdk/client-bedrock-runtime':
+        optional: true
+      '@aws-sdk/client-dynamodb':
+        optional: true
+      '@aws-sdk/client-kendra':
+        optional: true
+      '@aws-sdk/client-lambda':
+        optional: true
+      '@aws-sdk/client-sagemaker-runtime':
+        optional: true
+      '@aws-sdk/client-sfn':
+        optional: true
+      '@aws-sdk/credential-provider-node':
+        optional: true
+      '@azure/search-documents':
+        optional: true
+      '@clickhouse/client':
+        optional: true
+      '@cloudflare/ai':
+        optional: true
+      '@datastax/astra-db-ts':
+        optional: true
+      '@elastic/elasticsearch':
+        optional: true
+      '@getmetal/metal-sdk':
+        optional: true
+      '@getzep/zep-js':
+        optional: true
+      '@gomomento/sdk':
+        optional: true
+      '@gomomento/sdk-core':
+        optional: true
+      '@google-ai/generativelanguage':
+        optional: true
+      '@gradientai/nodejs-sdk':
+        optional: true
+      '@huggingface/inference':
+        optional: true
+      '@mozilla/readability':
+        optional: true
+      '@opensearch-project/opensearch':
+        optional: true
+      '@pinecone-database/pinecone':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@qdrant/js-client-rest':
+        optional: true
+      '@raycast/api':
+        optional: true
+      '@rockset/client':
+        optional: true
+      '@smithy/eventstream-codec':
+        optional: true
+      '@smithy/protocol-http':
+        optional: true
+      '@smithy/signature-v4':
+        optional: true
+      '@smithy/util-utf8':
+        optional: true
+      '@supabase/postgrest-js':
+        optional: true
+      '@supabase/supabase-js':
+        optional: true
+      '@tensorflow-models/universal-sentence-encoder':
+        optional: true
+      '@tensorflow/tfjs-converter':
+        optional: true
+      '@tensorflow/tfjs-core':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@upstash/vector':
+        optional: true
+      '@vercel/kv':
+        optional: true
+      '@vercel/postgres':
+        optional: true
+      '@writerai/writer-sdk':
+        optional: true
+      '@xata.io/client':
+        optional: true
+      '@xenova/transformers':
+        optional: true
+      '@zilliz/milvus2-sdk-node':
+        optional: true
+      better-sqlite3:
+        optional: true
+      cassandra-driver:
+        optional: true
+      chromadb:
+        optional: true
+      closevector-common:
+        optional: true
+      closevector-node:
+        optional: true
+      closevector-web:
+        optional: true
+      cohere-ai:
+        optional: true
+      convex:
+        optional: true
+      discord.js:
+        optional: true
+      dria:
+        optional: true
+      faiss-node:
+        optional: true
+      firebase-admin:
+        optional: true
+      google-auth-library:
+        optional: true
+      googleapis:
+        optional: true
+      hnswlib-node:
+        optional: true
+      html-to-text:
+        optional: true
+      ioredis:
+        optional: true
+      jsdom:
+        optional: true
+      llmonitor:
+        optional: true
+      lodash:
+        optional: true
+      lunary:
+        optional: true
+      mongodb:
+        optional: true
+      mysql2:
+        optional: true
+      neo4j-driver:
+        optional: true
+      node-llama-cpp:
+        optional: true
+      pg:
+        optional: true
+      pg-copy-streams:
+        optional: true
+      pickleparser:
+        optional: true
+      portkey-ai:
+        optional: true
+      redis:
+        optional: true
+      replicate:
+        optional: true
+      typeorm:
+        optional: true
+      typesense:
+        optional: true
+      usearch:
+        optional: true
+      vectordb:
+        optional: true
+      voy-search:
+        optional: true
+      weaviate-ts-client:
+        optional: true
+      web-auth-library:
+        optional: true
+      ws:
+        optional: true
+    dependencies:
+      '@langchain/core': 0.1.33
+      '@langchain/openai': 0.0.14
+      flat: 5.0.2
+      langsmith: 0.1.6
+      uuid: 9.0.1
+      zod: 3.22.4
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
+  /@langchain/core@0.1.33:
+    resolution: {integrity: sha512-1ZRNVEgK+N+Jq1XU6DJG8wW4MjdyA5nxk2LAK4rc8VuJf7D2Hzek8Gq99ToS6B0B32VK5z2HtHDsLMoYcdK/jA==}
+    engines: {node: '>=18'}
+    dependencies:
+      ansi-styles: 5.2.0
+      camelcase: 6.3.0
+      decamelize: 1.2.0
+      js-tiktoken: 1.0.8
+      langsmith: 0.1.6
+      ml-distance: 4.0.1
+      p-queue: 6.6.2
+      p-retry: 4.6.2
+      uuid: 9.0.1
+      zod: 3.22.4
+      zod-to-json-schema: 3.22.4(zod@3.22.4)
+    dev: false
+
+  /@langchain/mistralai@0.0.7:
+    resolution: {integrity: sha512-i0L463ojB9/LHSYo3MCYBWkCsb+qqNxD6PYRAJQ1fObSqLqpGIhRRIWegipIte8MFzIfREkOTiEQEbwIM1I7Wg==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@langchain/core': 0.1.33
+      '@mistralai/mistralai': 0.0.7
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
+  /@langchain/openai@0.0.14:
+    resolution: {integrity: sha512-co6nRylPrLGY/C3JYxhHt6cxLq07P086O7K3QaZH7SFFErIN9wSzJonpvhZR07DEUq6eK6wKgh2ORxA/NcjSRQ==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@langchain/core': 0.1.33
+      js-tiktoken: 1.0.8
+      openai: 4.28.0
+      zod: 3.22.4
+      zod-to-json-schema: 3.22.4(zod@3.22.4)
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
+  /@mistralai/mistralai@0.0.7:
+    resolution: {integrity: sha512-47FiV/GBnt6gug99ZfDBcBofYuYvqT5AyhUDdtktUbCN+gq52tmiAbtwc88k7hlyUWHzJ28VpHRDfNTRfaWKxA==}
+    dependencies:
+      axios: 1.6.7
+      axios-retry: 4.0.0(axios@1.6.7)
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
   /@nodelib/fs.scandir@2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -1311,6 +1637,25 @@ packages:
     resolution: {integrity: sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==}
     engines: {node: '>= 0.4'}
     dev: true
+
+  /axios-retry@4.0.0(axios@1.6.7):
+    resolution: {integrity: sha512-F6P4HVGITD/v4z9Lw2mIA24IabTajvpDZmKa6zq/gGwn57wN5j1P3uWrAV0+diqnW6kTM2fTqmWNfgYWGmMuiA==}
+    peerDependencies:
+      axios: 0.x || 1.x
+    dependencies:
+      axios: 1.6.7
+      is-retry-allowed: 2.2.0
+    dev: false
+
+  /axios@1.6.7:
+    resolution: {integrity: sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==}
+    dependencies:
+      follow-redirects: 1.15.5
+      form-data: 4.0.0
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+    dev: false
 
   /babel-jest@29.7.0(@babel/core@7.23.3):
     resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
@@ -2336,6 +2681,16 @@ packages:
     resolution: {integrity: sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==}
     dev: true
 
+  /follow-redirects@1.15.5:
+    resolution: {integrity: sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dev: false
+
   /for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
     dependencies:
@@ -2765,6 +3120,11 @@ packages:
 
   /is-relative-path@1.0.2:
     resolution: {integrity: sha512-i1h+y50g+0hRbBD+dbnInl3JlJ702aar58snAeX+MxBAPvzXGej7sYoPMhlnykabt0ZzCJNBEyzMlekuQZN7fA==}
+    dev: false
+
+  /is-retry-allowed@2.2.0:
+    resolution: {integrity: sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==}
+    engines: {node: '>=10'}
     dev: false
 
   /is-shared-array-buffer@1.0.2:
@@ -3373,116 +3733,62 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /langchain@0.0.172:
-    resolution: {integrity: sha512-HsUpAJmR3UPWmjuDckItddRPor5gViOQ3p+SgLMHJj4QR9igJi0YqE6g1x2iqSH6GH8ZP45dgP014xvK2vBsYA==}
+  /langchain@0.1.21(axios@1.6.7):
+    resolution: {integrity: sha512-OOcCFIgx23WyyNS1VJBLbC3QL5plQBVfp2drXw1OJAarZ8yEY3cgJq8NbTY37sMnLoJ2olFEzMuAOdlTur4cwQ==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@aws-crypto/sha256-js': ^5.0.0
-      '@aws-sdk/client-bedrock-runtime': ^3.422.0
-      '@aws-sdk/client-dynamodb': ^3.310.0
-      '@aws-sdk/client-kendra': ^3.352.0
-      '@aws-sdk/client-lambda': ^3.310.0
       '@aws-sdk/client-s3': ^3.310.0
       '@aws-sdk/client-sagemaker-runtime': ^3.310.0
       '@aws-sdk/client-sfn': ^3.310.0
       '@aws-sdk/credential-provider-node': ^3.388.0
       '@azure/storage-blob': ^12.15.0
-      '@clickhouse/client': ^0.0.14
-      '@cloudflare/ai': ^1.0.12
-      '@elastic/elasticsearch': ^8.4.0
-      '@getmetal/metal-sdk': '*'
-      '@getzep/zep-js': ^0.8.0
-      '@gomomento/sdk': ^1.44.1
-      '@gomomento/sdk-core': ^1.44.1
-      '@gomomento/sdk-web': ^1.44.1
+      '@gomomento/sdk': ^1.51.1
+      '@gomomento/sdk-core': ^1.51.1
+      '@gomomento/sdk-web': ^1.51.1
       '@google-ai/generativelanguage': ^0.2.1
-      '@google-cloud/storage': ^6.10.1
-      '@huggingface/inference': ^1.5.1
-      '@mozilla/readability': '*'
+      '@google-cloud/storage': ^6.10.1 || ^7.7.0
       '@notionhq/client': ^2.2.10
-      '@opensearch-project/opensearch': '*'
-      '@pinecone-database/pinecone': ^1.1.0
-      '@planetscale/database': ^1.8.0
-      '@qdrant/js-client-rest': ^1.2.0
-      '@raycast/api': ^1.55.2
-      '@smithy/eventstream-codec': ^2.0.5
-      '@smithy/protocol-http': ^3.0.6
-      '@smithy/signature-v4': ^2.0.10
-      '@smithy/util-utf8': ^2.0.0
-      '@supabase/postgrest-js': ^1.1.1
+      '@pinecone-database/pinecone': '*'
       '@supabase/supabase-js': ^2.10.0
-      '@tensorflow-models/universal-sentence-encoder': '*'
-      '@tensorflow/tfjs-converter': '*'
-      '@tensorflow/tfjs-core': '*'
-      '@upstash/redis': ^1.20.6
       '@vercel/kv': ^0.2.3
-      '@vercel/postgres': ^0.5.0
-      '@writerai/writer-sdk': ^0.40.2
-      '@xata.io/client': ^0.25.1
-      '@xenova/transformers': ^2.5.4
-      '@zilliz/milvus2-sdk-node': '>=2.2.7'
+      '@xata.io/client': ^0.28.0
       apify-client: ^2.7.1
-      assemblyai: ^2.0.2
+      assemblyai: ^4.0.0
       axios: '*'
-      cassandra-driver: ^4.6.4
       cheerio: ^1.0.0-rc.12
       chromadb: '*'
-      closevector-common: 0.1.0-alpha.1
-      closevector-node: 0.1.0-alpha.10
-      closevector-web: 0.1.0-alpha.16
-      cohere-ai: '>=6.0.0'
+      convex: ^1.3.1
+      couchbase: ^4.2.10
       d3-dsv: ^2.0.0
       epub2: ^3.0.1
-      faiss-node: ^0.5.1
+      faiss-node: '*'
       fast-xml-parser: ^4.2.7
-      firebase-admin: ^11.9.0
       google-auth-library: ^8.9.0
-      googleapis: ^126.0.1
-      hnswlib-node: ^1.4.2
+      handlebars: ^4.7.8
       html-to-text: ^9.0.5
       ignore: ^5.2.0
       ioredis: ^5.3.2
       jsdom: '*'
-      llmonitor: ^0.5.8
-      lodash: ^4.17.21
-      mammoth: '*'
-      mongodb: ^5.2.0
-      mysql2: ^3.3.3
-      neo4j-driver: '*'
+      mammoth: ^1.6.0
+      mongodb: '>=5.2.0'
       node-llama-cpp: '*'
       notion-to-md: ^3.1.0
+      officeparser: ^4.0.4
       pdf-parse: 1.1.1
       peggy: ^3.0.2
-      pg: ^8.11.0
-      pg-copy-streams: ^6.0.5
-      pickleparser: ^0.2.1
       playwright: ^1.32.1
-      portkey-ai: ^0.1.11
       puppeteer: ^19.7.2
+      pyodide: ^0.24.1
       redis: ^4.6.4
-      replicate: ^0.18.0
       sonix-speech-recognition: ^2.1.1
-      srt-parser-2: ^1.2.2
+      srt-parser-2: ^1.2.3
       typeorm: ^0.3.12
-      typesense: ^1.5.3
-      usearch: ^1.1.1
-      vectordb: ^0.1.4
-      voy-search: 0.6.2
-      weaviate-ts-client: ^1.4.0
+      weaviate-ts-client: '*'
       web-auth-library: ^1.0.3
+      ws: ^8.14.2
       youtube-transcript: ^1.0.6
       youtubei.js: ^5.8.0
     peerDependenciesMeta:
-      '@aws-crypto/sha256-js':
-        optional: true
-      '@aws-sdk/client-bedrock-runtime':
-        optional: true
-      '@aws-sdk/client-dynamodb':
-        optional: true
-      '@aws-sdk/client-kendra':
-        optional: true
-      '@aws-sdk/client-lambda':
-        optional: true
       '@aws-sdk/client-s3':
         optional: true
       '@aws-sdk/client-sagemaker-runtime':
@@ -3492,16 +3798,6 @@ packages:
       '@aws-sdk/credential-provider-node':
         optional: true
       '@azure/storage-blob':
-        optional: true
-      '@clickhouse/client':
-        optional: true
-      '@cloudflare/ai':
-        optional: true
-      '@elastic/elasticsearch':
-        optional: true
-      '@getmetal/metal-sdk':
-        optional: true
-      '@getzep/zep-js':
         optional: true
       '@gomomento/sdk':
         optional: true
@@ -3513,53 +3809,15 @@ packages:
         optional: true
       '@google-cloud/storage':
         optional: true
-      '@huggingface/inference':
-        optional: true
-      '@mozilla/readability':
-        optional: true
       '@notionhq/client':
-        optional: true
-      '@opensearch-project/opensearch':
         optional: true
       '@pinecone-database/pinecone':
         optional: true
-      '@planetscale/database':
-        optional: true
-      '@qdrant/js-client-rest':
-        optional: true
-      '@raycast/api':
-        optional: true
-      '@smithy/eventstream-codec':
-        optional: true
-      '@smithy/protocol-http':
-        optional: true
-      '@smithy/signature-v4':
-        optional: true
-      '@smithy/util-utf8':
-        optional: true
-      '@supabase/postgrest-js':
-        optional: true
       '@supabase/supabase-js':
-        optional: true
-      '@tensorflow-models/universal-sentence-encoder':
-        optional: true
-      '@tensorflow/tfjs-converter':
-        optional: true
-      '@tensorflow/tfjs-core':
-        optional: true
-      '@upstash/redis':
         optional: true
       '@vercel/kv':
         optional: true
-      '@vercel/postgres':
-        optional: true
-      '@writerai/writer-sdk':
-        optional: true
       '@xata.io/client':
-        optional: true
-      '@xenova/transformers':
-        optional: true
-      '@zilliz/milvus2-sdk-node':
         optional: true
       apify-client:
         optional: true
@@ -3567,19 +3825,13 @@ packages:
         optional: true
       axios:
         optional: true
-      cassandra-driver:
-        optional: true
       cheerio:
         optional: true
       chromadb:
         optional: true
-      closevector-common:
+      convex:
         optional: true
-      closevector-node:
-        optional: true
-      closevector-web:
-        optional: true
-      cohere-ai:
+      couchbase:
         optional: true
       d3-dsv:
         optional: true
@@ -3589,13 +3841,9 @@ packages:
         optional: true
       fast-xml-parser:
         optional: true
-      firebase-admin:
-        optional: true
       google-auth-library:
         optional: true
-      googleapis:
-        optional: true
-      hnswlib-node:
+      handlebars:
         optional: true
       html-to-text:
         optional: true
@@ -3605,41 +3853,27 @@ packages:
         optional: true
       jsdom:
         optional: true
-      llmonitor:
-        optional: true
-      lodash:
-        optional: true
       mammoth:
         optional: true
       mongodb:
-        optional: true
-      mysql2:
-        optional: true
-      neo4j-driver:
         optional: true
       node-llama-cpp:
         optional: true
       notion-to-md:
         optional: true
+      officeparser:
+        optional: true
       pdf-parse:
         optional: true
       peggy:
         optional: true
-      pg:
-        optional: true
-      pg-copy-streams:
-        optional: true
-      pickleparser:
-        optional: true
       playwright:
-        optional: true
-      portkey-ai:
         optional: true
       puppeteer:
         optional: true
-      redis:
+      pyodide:
         optional: true
-      replicate:
+      redis:
         optional: true
       sonix-speech-recognition:
         optional: true
@@ -3647,55 +3881,106 @@ packages:
         optional: true
       typeorm:
         optional: true
-      typesense:
-        optional: true
-      usearch:
-        optional: true
-      vectordb:
-        optional: true
-      voy-search:
-        optional: true
       weaviate-ts-client:
         optional: true
       web-auth-library:
+        optional: true
+      ws:
         optional: true
       youtube-transcript:
         optional: true
       youtubei.js:
         optional: true
     dependencies:
-      '@anthropic-ai/sdk': 0.6.8
-      ansi-styles: 5.2.0
+      '@anthropic-ai/sdk': 0.9.1
+      '@langchain/community': 0.0.32
+      '@langchain/core': 0.1.33
+      '@langchain/openai': 0.0.14
+      axios: 1.6.7
       binary-extensions: 2.2.0
-      camelcase: 6.3.0
-      decamelize: 1.2.0
       expr-eval: 2.0.2
-      flat: 5.0.2
       js-tiktoken: 1.0.8
       js-yaml: 4.1.0
       jsonpointer: 5.0.1
-      langchainhub: 0.0.6
-      langsmith: 0.0.48
+      langchainhub: 0.0.8
+      langsmith: 0.1.6
       ml-distance: 4.0.1
-      object-hash: 3.0.0
-      openai: 4.4.0
       openapi-types: 12.1.3
-      p-queue: 6.6.2
       p-retry: 4.6.2
       uuid: 9.0.1
       yaml: 2.3.4
       zod: 3.22.4
-      zod-to-json-schema: 3.22.0(zod@3.22.4)
+      zod-to-json-schema: 3.22.4(zod@3.22.4)
     transitivePeerDependencies:
+      - '@aws-crypto/sha256-js'
+      - '@aws-sdk/client-bedrock-agent-runtime'
+      - '@aws-sdk/client-bedrock-runtime'
+      - '@aws-sdk/client-dynamodb'
+      - '@aws-sdk/client-kendra'
+      - '@aws-sdk/client-lambda'
+      - '@azure/search-documents'
+      - '@clickhouse/client'
+      - '@cloudflare/ai'
+      - '@datastax/astra-db-ts'
+      - '@elastic/elasticsearch'
+      - '@getmetal/metal-sdk'
+      - '@getzep/zep-js'
+      - '@gradientai/nodejs-sdk'
+      - '@huggingface/inference'
+      - '@mozilla/readability'
+      - '@opensearch-project/opensearch'
+      - '@planetscale/database'
+      - '@qdrant/js-client-rest'
+      - '@raycast/api'
+      - '@rockset/client'
+      - '@smithy/eventstream-codec'
+      - '@smithy/protocol-http'
+      - '@smithy/signature-v4'
+      - '@smithy/util-utf8'
+      - '@supabase/postgrest-js'
+      - '@tensorflow-models/universal-sentence-encoder'
+      - '@tensorflow/tfjs-converter'
+      - '@tensorflow/tfjs-core'
+      - '@upstash/redis'
+      - '@upstash/vector'
+      - '@vercel/postgres'
+      - '@writerai/writer-sdk'
+      - '@xenova/transformers'
+      - '@zilliz/milvus2-sdk-node'
+      - better-sqlite3
+      - cassandra-driver
+      - closevector-common
+      - closevector-node
+      - closevector-web
+      - cohere-ai
+      - discord.js
+      - dria
       - encoding
+      - firebase-admin
+      - googleapis
+      - hnswlib-node
+      - llmonitor
+      - lodash
+      - lunary
+      - mysql2
+      - neo4j-driver
+      - pg
+      - pg-copy-streams
+      - pickleparser
+      - portkey-ai
+      - replicate
+      - typesense
+      - usearch
+      - vectordb
+      - voy-search
     dev: false
 
-  /langchainhub@0.0.6:
-    resolution: {integrity: sha512-SW6105T+YP1cTe0yMf//7kyshCgvCTyFBMTgH2H3s9rTAR4e+78DA/BBrUL/Mt4Q5eMWui7iGuAYb3pgGsdQ9w==}
+  /langchainhub@0.0.8:
+    resolution: {integrity: sha512-Woyb8YDHgqqTOZvWIbm2CaFDGfZ4NTSyXV687AG4vXEfoNo7cGQp7nhl7wL3ehenKWmNEmcxCLgOZzW8jE6lOQ==}
     dev: false
 
-  /langsmith@0.0.48:
-    resolution: {integrity: sha512-s0hW8iZ90Q9XLTnDK0Pgee245URV3b1cXQjPDj5OKm1+KN7iSK1pKx+4CO7RcFLz58Ixe7Mt+mVcomYqUuryxQ==}
+  /langsmith@0.1.6:
+    resolution: {integrity: sha512-pLwepjtA7ki4aK20L1KqbJi55f10KVHHOSPAqzoNnAZqWv/YlHyxHhNrY/Nkxb+rM+hKLZNBMpmjlgvceEQtvw==}
     hasBin: true
     dependencies:
       '@types/uuid': 9.0.7
@@ -3954,11 +4239,6 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
-  /object-hash@3.0.0:
-    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
-    engines: {node: '>= 6'}
-    dev: false
-
   /object-inspect@1.13.1:
     resolution: {integrity: sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==}
     dev: true
@@ -4017,8 +4297,8 @@ packages:
       mimic-fn: 2.1.0
     dev: true
 
-  /openai@4.4.0:
-    resolution: {integrity: sha512-JN0t628Kh95T0IrXl0HdBqnlJg+4Vq0Bnh55tio+dfCnyzHvMLiWyCM9m726MAJD2YkDU4/8RQB6rNbEq9ct2w==}
+  /openai@4.28.0:
+    resolution: {integrity: sha512-JM8fhcpmpGN0vrUwGquYIzdcEQHtFuom6sRCbbCM6CfzZXNuRk33G7KfeRAIfnaCxSpzrP5iHtwJzIm6biUZ2Q==}
     hasBin: true
     dependencies:
       '@types/node': 18.18.12
@@ -4029,6 +4309,7 @@ packages:
       form-data-encoder: 1.7.2
       formdata-node: 4.4.1
       node-fetch: 2.7.0
+      web-streams-polyfill: 3.2.1
     transitivePeerDependencies:
       - encoding
     dev: false
@@ -4238,6 +4519,10 @@ packages:
       kleur: 3.0.3
       sisteransi: 1.0.5
     dev: true
+
+  /proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+    dev: false
 
   /punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -4985,8 +5270,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /zod-to-json-schema@3.22.0(zod@3.22.4):
-    resolution: {integrity: sha512-XQr8EwxPMzJGhoR+d/nRFWdi15VaZ+R5Uhssm+Xx5yS30xCpuutfKRm4rerE0SK9j2dWB5Z3FvDD0w8WMVGzkA==}
+  /zod-to-json-schema@3.22.4(zod@3.22.4):
+    resolution: {integrity: sha512-2Ed5dJ+n/O3cU383xSY28cuVi0BCQhF8nYqWU5paEpl7fVdqdAmiLdqLyfblbNdfOFwFfi/mqU4O1pwc60iBhQ==}
     peerDependencies:
       zod: ^3.22.4
     dependencies:

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -7,6 +7,16 @@ function checkRequiredFields(args: RawConfig) {
     throw new Error('An outpath path is required')
   }
 
+  if (!['openAI', 'mistral'].includes(args.modelProvider)) {
+    throw new Error(
+      'Only openAI and mistral llm are supported. Please choose one with modelProvider argument'
+    )
+  }
+
+  if (!args.modelName) {
+    throw new Error('A modelName is required. Please fill modelName argument')
+  }
+
   if (!args.entrypoint && !args.serverless) {
     throw new Error(
       'You have to pass an entrypoint or a serverless path or a files array'
@@ -15,10 +25,8 @@ function checkRequiredFields(args: RawConfig) {
 }
 
 export async function cli(cliArgs: string[]): Promise<void> {
-  console.log('Generating your documentation...')
-
-  if (!process.env.OPENAI_API_KEY) {
-    throw new Error('Missing ENV OPENAI_API_KEY')
+  if (!process.env.API_KEY) {
+    throw new Error('You have to provide an API_KEY')
   }
 
   const args = minimist(cliArgs) as any as RawConfig
@@ -29,10 +37,11 @@ export async function cli(cliArgs: string[]): Promise<void> {
     outputDir: args.output,
     isMocked: Boolean(args.mocked),
     baseDir: args.basedir ?? '',
-    openAi: {
+    llm: {
       temperature: args.temperature,
       modelName: args.modelName,
-      apiKey: process.env.OPENAI_API_KEY
+      modelProvider: args.modelProvider as 'openAI' | 'mistral',
+      apiKey: process.env.API_KEY
     },
     files: [],
     entryPoint: args.entrypoint,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import path from 'path'
 import { addCommentsPerFile } from './add-comment/index.js'
 import { generateMarkdownFromCommentedCode } from './generate-doc/index.js'
 import { getHandlerPaths } from './plugins/serverless/index.js'
-import { initializeOpenAI } from './llm/model.js'
+import { initializeModel } from './llm/model.js'
 import type { Config, EntryConfigDocai } from './types/internal.js'
 import { writeMarkdownFile } from './generate-doc/write-markdown.js'
 
@@ -11,8 +11,18 @@ function checkRequiredFields(config: EntryConfigDocai) {
     throw new Error('An outpath directory is required. Please fill outputDir')
   }
 
-  if (!config.openAi?.apiKey) {
-    throw new Error('An OpenAI API KEY is required. Please fill openAI.apiKey')
+  if (!config.llm?.apiKey) {
+    throw new Error('An API KEY is required. Please fill llm.apiKey')
+  }
+
+  if (!['openAI', 'mistral'].includes(config.llm?.modelProvider)) {
+    throw new Error(
+      'Only openAI and mistral llm are supported. Please choose one'
+    )
+  }
+
+  if (!config.llm?.modelName) {
+    throw new Error('A modelName is required. Please fill llm.modelName')
   }
 
   if (
@@ -28,7 +38,7 @@ function checkRequiredFields(config: EntryConfigDocai) {
 
 export async function docai(configArgs: EntryConfigDocai): Promise<void> {
   checkRequiredFields(configArgs)
-  initializeOpenAI(configArgs.openAi)
+  initializeModel(configArgs.llm)
 
   const config: Config = {
     ...configArgs,

--- a/src/llm/llm.ts
+++ b/src/llm/llm.ts
@@ -1,27 +1,34 @@
 import { getModel } from '../llm/model.js'
+import { ChatPromptTemplate } from '@langchain/core/prompts'
 
 export async function generateMarkdown(
   code: string,
   title: string
-): Promise<string> {
-  const res = await getModel().call(
-    `You have to write a markdown documentation page for this file: ${code}
+): Promise<any> {
+  const prompt = ChatPromptTemplate.fromTemplate(
+    `You have to write a markdown documentation page for this file: {code}
     It should contain only these parts:
-    # ${title}
+    # {title}
     ## Description <!-- Explain what the code does, using the comments you'll find in the code. -->
     ## Code <!-- This section should contains raw code, formatted in Javascript. -->
     ## Use Cases <!-- If you can, give examples to explain what this file does. You can do it by writing a code block which executes functions from the file and display results from their execution in comments. -->`
   )
+  const chain = prompt.pipe(getModel())
 
-  return res
+  const res = await chain.invoke({ code, title })
+
+  return res.lc_kwargs.content
 }
 
-export async function generateCommentFromCode(text: string): Promise<string> {
-  const res = await getModel().call(
-    `Explain what this code does as fully as possible: ${text}`
+export async function generateCommentFromCode(text: string): Promise<any> {
+  const prompt = ChatPromptTemplate.fromTemplate(
+    'Explain what this code does as fully as possible: {text}'
   )
+  const chain = prompt.pipe(getModel())
 
-  return res
+  const res = await chain.invoke({ text })
+
+  return res.lc_kwargs.content
 }
 
 export default {

--- a/src/llm/model.ts
+++ b/src/llm/model.ts
@@ -1,25 +1,43 @@
-import { OpenAI } from 'langchain/llms/openai'
+import { ChatMistralAI } from '@langchain/mistralai'
+import { ChatOpenAI } from '@langchain/openai'
 
-let model: OpenAI | undefined
+let model: ChatOpenAI | ChatMistralAI | undefined
 
-export function initializeOpenAI({
-  modelName = 'gpt-4',
+export type MODEL = ChatOpenAI | ChatMistralAI
+
+export function initializeModel({
+  modelProvider,
+  modelName,
   temperature = 0,
   apiKey
-}): OpenAI {
+}): MODEL {
   if (!apiKey) throw new Error('Missing apiKey')
 
-  if (!model) {
-    model = new OpenAI({
-      openAIApiKey: apiKey,
-      modelName,
-      temperature
-    })
+  switch (modelProvider) {
+    case 'openAI':
+      model = new ChatOpenAI({
+        openAIApiKey: apiKey,
+        modelName,
+        temperature
+      })
+      break
+    case 'mistral':
+      model = new ChatMistralAI({
+        apiKey,
+        modelName,
+        temperature
+      })
+      break
+    default:
+      throw new Error(
+        'Only openAI and mistral llm are supported. Please choose one'
+      )
   }
+
   return model
 }
 
-export function getModel(): OpenAI {
+export function getModel(): MODEL {
   if (!model) {
     throw new Error('Model has not been initialized yet')
   }

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -7,16 +7,24 @@ export type RawConfig = {
   entrypoint?: string
   serverless?: string
   temperature?: number
-  modelName?: string
+  modelName: string
+  modelProvider: string
   noDeleteTmp?: boolean
   tmpDirPath?: string
 }
 
 export type EntryConfigDocai = {
   outputDir: string
-  openAi: {
+  llm: {
     temperature?: number
-    modelName?: string
+    modelName:
+      | 'gpt-4'
+      | 'gpt-3.5'
+      | 'mistral-tiny'
+      | 'mistral-small'
+      | 'mistral-medium'
+      | string
+    modelProvider: 'openAI' | 'mistral'
     apiKey: string
   }
   baseDir?: string
@@ -30,9 +38,10 @@ export type EntryConfigDocai = {
 
 export type Config = {
   outputDir: string
-  openAi: {
+  llm: {
     temperature?: number
-    modelName?: string
+    modelName: string
+    modelProvider: string
     apiKey: string
   }
   files?: string[]

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,7 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["src", "bin"],
-  "compilerOptions": {
-    "outDir": "./dist"
-  }
+  "include": ["src", "bin"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "noFallthroughCasesInSwitch": true,
     "typeRoots": ["./node_modules/@types"],
     "inlineSourceMap": true,
-    "noUnusedLocals": false
+    "noUnusedLocals": false,
+    "outDir": "./dist"
   }
 }


### PR DESCRIPTION
This MR allows to use Mistral as an alternative to ChatGPT to generative doc.

It contains breaking change : 
   - **modelName** is required, the default value to gpt-4 was removed
   - **modelProvider is required you can choose between 'mistral' or 'openAI'
   - **openAi** object was deleted and replaced by : 
```
   llm: {
    apiKey: 'YOUR_API_KEY'
    modelProvider:
    modelName: 'mistral-tiny' | 'gpt-4' | '...'
}
```
   - OPEN_API_KEY env was renamed to API_KEY for the CLI version
