### PR TITLE
Add the possibility to customize the prompt template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.0] - 2024-05-16
+
+- Add the possibility to customize the prompt template used to instruct the LLM to create code documentation.
+  Just pass `--template` to the CLI, or `template` to the Docai module.
+
 ## [2.2.0] - 2024-05-09
 
 - Support to generate documentation locally with Ollama.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ await docai({
   - `temperature`: Temperature setting for the used model (0 by default).
 - `deleteTmpFolder`: Flag to decide whether or not to delete the temporary folder.
 - `tmpFolderPath`: Path for the temporary folder.
+- `template`: Prompt template send to the LLM to document the code, default value can be found [here](https://github.com/zgababa/docai/blob/main/src/llm/llm.ts)
 
 ### CLI
 
@@ -108,6 +109,7 @@ API_KEY="YOUR_API_KEY" docai --output ./documentation --modelProvider openAI --m
 - `temperature`: Temperature setting for the used model (0 by default). (Optional)
 - `noDeleteTmp`: Flag to decide whether or not to delete the temporary folder. (Optional)
 - `tmpFolderPath`: Path for the temporary folder. (Optional)
+- `template`: Prompt template send to the LLM to document the code, default value can be found [here](https://github.com/zgababa/docai/blob/main/src/llm/llm.ts). (Optional)
 
 ### Environment Variables:
 
@@ -166,8 +168,6 @@ You can examine the code found in \_mock/test/raw/src and compare it to the docu
 
 ## Upcoming Features:
 
-- Templating.
-- Support for multiple LLMs.
 - Multiple entry points.
 - Multilingual capabilities.
 - Frontend application documentation.

--- a/__tests__/unit/cli/cli.spec.ts
+++ b/__tests__/unit/cli/cli.spec.ts
@@ -245,13 +245,16 @@ describe('CLI Unit', () => {
       '--modelProvider',
       'mistral',
       '--modelName',
-      'mistral-tiny'
+      'mistral-tiny',
+      '--template',
+      'my-template'
     ])
     expect(generateMarkdownFromCommentedCode).toHaveBeenCalledWith(
       '/tmp/commented',
       Object.assign({}, config, {
         entryPoint: 'fake/entry.js',
-        serverlessEntryPoint: undefined
+        serverlessEntryPoint: undefined,
+        template: 'my-template'
       })
     )
   })

--- a/__tests__/unit/generate-doc/get-markdown.spec.ts
+++ b/__tests__/unit/generate-doc/get-markdown.spec.ts
@@ -52,6 +52,29 @@ describe('getMarkdown', () => {
     )
 
     expect(result).toBe('Generated Markdown Content')
-    expect(generateMarkdown).toHaveBeenCalledWith('codeContent', 'title')
+    expect(generateMarkdown).toHaveBeenCalledWith(
+      'codeContent',
+      'title',
+      undefined
+    )
+  })
+
+  it('Should generate markdown with template', async () => {
+    toJestMock(generateMarkdown).mockResolvedValue('Generated Markdown Content')
+
+    const result = await getMarkdown(
+      'any-path.js',
+      'codeContent',
+      'title',
+      false,
+      'template'
+    )
+
+    expect(result).toBe('Generated Markdown Content')
+    expect(generateMarkdown).toHaveBeenCalledWith(
+      'codeContent',
+      'title',
+      'template'
+    )
   })
 })

--- a/__tests__/unit/generate-doc/write-markdown.spec.ts
+++ b/__tests__/unit/generate-doc/write-markdown.spec.ts
@@ -36,7 +36,8 @@ describe('writeMarkdownFile', () => {
 
     const fn = writeMarkdownFile(originalDir, {
       outputDir: '/mock/websiteDir',
-      isMocked: true
+      isMocked: true,
+      template: 'template'
     } as any)
     await fn(inputFilePath)
 
@@ -44,7 +45,8 @@ describe('writeMarkdownFile', () => {
       inputFilePath,
       codeContent,
       title,
-      true
+      true,
+      'template'
     )
     expect(getOutputFilePath).toHaveBeenCalledWith(
       inputFilePath,

--- a/__tests__/unit/index.spec.ts
+++ b/__tests__/unit/index.spec.ts
@@ -22,7 +22,8 @@ describe('Docai index', () => {
       apiKey: 'test-key',
       modelName: 'gpt-4',
       modelProvider: 'openAI'
-    }
+    },
+    template: 'template'
   }
 
   afterEach(() => {

--- a/__tests__/unit/llm/llm.spec.ts
+++ b/__tests__/unit/llm/llm.spec.ts
@@ -16,6 +16,18 @@ describe('llm', () => {
     it('Should call the llm with correct parameters', async () => {
       const code = 'code'
       const title = 'title'
+      const template = 'template'
+
+      const result = await generateMarkdown(code, title, template)
+
+      expect(ChatPromptTemplate.fromTemplate).toHaveBeenCalledTimes(1)
+      expect(ChatPromptTemplate.fromTemplate).toHaveBeenCalledWith('template')
+      expect(getModel).toHaveBeenCalledTimes(1)
+      expect(result).toBe('mocked content')
+    })
+    it('Should call the llm with default template', async () => {
+      const code = 'code'
+      const title = 'title'
 
       const result = await generateMarkdown(code, title)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docai",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Generate documentation from your code with AI",
   "main": "./dist/src/index.js",
   "type": "module",

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -63,6 +63,7 @@ export async function cli(cliArgs: string[]): Promise<void> {
     entryPoint: args.entrypoint,
     serverlessEntryPoint: args.serverless,
     deleteTmpFolder: !args.noDeleteTmp,
-    tmpFolderPath: args.tmpDirPath ?? ''
+    tmpFolderPath: args.tmpDirPath ?? '',
+    template: args.template
   })
 }

--- a/src/generate-doc/get-markdown.ts
+++ b/src/generate-doc/get-markdown.ts
@@ -6,7 +6,8 @@ export async function getMarkdown(
   inputFilePath: string,
   codeContent: string,
   title: string,
-  isMocked: boolean
+  isMocked: boolean,
+  template?: string
 ): Promise<string> {
   if (isMocked) {
     if (!cacheMocked[inputFilePath]) {
@@ -15,5 +16,5 @@ export async function getMarkdown(
     return fs.readFileSync(cacheMocked[inputFilePath], 'utf-8')
   }
 
-  return await generateMarkdown(codeContent, title)
+  return await generateMarkdown(codeContent, title, template)
 }

--- a/src/generate-doc/write-markdown.ts
+++ b/src/generate-doc/write-markdown.ts
@@ -21,7 +21,8 @@ export function writeMarkdownFile(originalDir: string, config: Config) {
       inputFilePath,
       codeContent,
       title,
-      config.isMocked
+      config.isMocked,
+      config.template
     )
     const outputFilePath = getOutputFilePath(
       inputFilePath,

--- a/src/llm/llm.ts
+++ b/src/llm/llm.ts
@@ -3,16 +3,19 @@ import { ChatPromptTemplate } from '@langchain/core/prompts'
 
 export async function generateMarkdown(
   code: string,
-  title: string
+  title: string,
+  template?: string
 ): Promise<any> {
-  const prompt = ChatPromptTemplate.fromTemplate(
+  const chatTemplate =
+    template ??
     `You have to write a markdown documentation page for this file: {code}
     It should contain only these parts:
     # {title}
     ## Description <!-- Explain what the code does, using the comments you'll find in the code. -->
     ## Code <!-- This section should contains raw code, formatted in Javascript. -->
     ## Use Cases <!-- If you can, give examples to explain what this file does. You can do it by writing a code block which executes functions from the file and display results from their execution in comments. -->`
-  )
+
+  const prompt = ChatPromptTemplate.fromTemplate(chatTemplate)
   const chain = prompt.pipe(getModel())
 
   const res = await chain.invoke({ code, title })

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -15,6 +15,7 @@ export type RawConfig = {
   tmpDirPath?: string
   local?: boolean
   baseUrl?: string
+  template?: string
 }
 
 type BaseEntryConfigDocai = {
@@ -26,6 +27,7 @@ type BaseEntryConfigDocai = {
   serverlessEntryPoint?: string
   deleteTmpFolder?: boolean
   tmpFolderPath?: string
+  template?: string
 }
 
 export type EntryConfigDocai =
@@ -63,6 +65,7 @@ type BaseConfig = {
   isMocked: boolean
   deleteTmpFolder: boolean
   tmpFolderPath: string
+  template?: string
 }
 
 export type Config =


### PR DESCRIPTION
 Add the possibility to customize the prompt template used to instruct the LLM to create code documentation.
  Just pass `--template` to the CLI, or `template` to the Docai module.